### PR TITLE
Update logic.js

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -133,15 +133,16 @@ function placePixel(off) {
  */
 
 function mouseWheel(event) {
-
-  //move the square according to the vertical scroll amount
-  if(brushSize-event.delta/100 > 0 && brushSize-event.delta/100 < brushSizeMax){
-    console.log(brushSize)
-    console.log("adjusting Brush");
-    brushSize += event.delta/100; //scales down the event because typical delta ~100
-    console.log(brushSize,"new Size")
+  console.log(brushSize)
+  console.log("adjusting Brush");
+  brushSize += event.delta / 100; //scales down the event because typical delta ~100
+  if (brushSize < brushSizeMin) {
+    brushSize = brushSizeMin;
+  } else if (brushSize > brushSizeMax) {
+    brushSize = brushSizeMax;
   }
-  
+  console.log(brushSize, "new Size")
+
   //uncomment to block page scrolling
   return false;
 }


### PR DESCRIPTION
Fixed mouseWheelEvent to enforce min/max brushSize (there was a bug before where you could scroll past the limits and break the ability to change brushSize)